### PR TITLE
making this work as an archival docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Tessel was designed for web developers to work in the world of hardware for the 
 
 ## Tessel 1 API Documentation
 
-* [Tessel 1 CLI](https://github.com/tessel/docs/blob/master/cli.md)
-* [Tessel 1 Hardware API (LEDs, pins, ports, etc.)](https://github.com/tessel/docs/blob/master/hardware-api.md)
-* [Modules on Tessel 1](https://github.com/tessel/docs/blob/master/module-apis.md)
-* [Connecting Tessel 1 to Wifi](https://github.com/tessel/docs/blob/master/wifi.md)
-* [Tessel 1 Languages and Compatibility](https://github.com/tessel/docs/blob/master/compatibility.md)
+* [Tessel 1 CLI](https://github.com/tessel/t1-docs/blob/master/cli.md)
+* [Tessel 1 Hardware API (LEDs, pins, ports, etc.)](https://github.com/tessel/t1-docs/blob/master/hardware-api.md)
+* [Modules on Tessel 1](https://github.com/tessel/t1-docs/blob/master/module-apis.md)
+* [Connecting Tessel 1 to Wifi](https://github.com/tessel/t1-docs/blob/master/wifi.md)
+* [Tessel 1 Languages and Compatibility](https://github.com/tessel/t1-docs/blob/master/compatibility.md)
 
 ## Tessel 1 Hardware Documentation
 
@@ -33,10 +33,10 @@ Tessel was designed for web developers to work in the world of hardware for the 
 
 ## Tessel 1 Tutorials
 
-* [Communication protocols](https://github.com/tessel/docs/blob/master/tutorials/communication-protocols.md)
-* [Making a DIY module](https://github.com/tessel/docs/blob/master/tutorials/diy_module_creation.md)
-* [Using multiple modules](https://github.com/tessel/docs/blob/master/tutorials/multi-module.md)
-* [Untethering Tessel](https://github.com/tessel/docs/blob/master/tutorials/untethered.md)
+* [Communication protocols](https://github.com/tessel/t1-docs/blob/master/tutorials/communication-protocols.md)
+* [Making a DIY module](https://github.com/tessel/t1-docs/blob/master/tutorials/diy_module_creation.md)
+* [Using multiple modules](https://github.com/tessel/t1-docs/blob/master/tutorials/multi-module.md)
+* [Untethering Tessel](https://github.com/tessel/t1-docs/blob/master/tutorials/untethered.md)
 
 If there's anything you can't find, something that isn't working, or documentation that we should add, please don't hesitate to <b>reach out to us</b> on the [Tessel forums](//forums.tessel.io).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-Tessel Documentation
+Tessel 1 Documentation
 ====
+
+*If you are looking for Tessel 2 documentation, go to [tessel.io/docs](//tessel.io/docs). Most of the documentation in this repo is archival.*
 
 This is Tessel. Think of it as a tiny server, or a tiny robot you can control from the internet.
 
@@ -13,11 +15,32 @@ Tessel was designed for web developers to work in the world of hardware for the 
 
 <b>To install and get started with Tessel,</b> launch our [First Run Experience](//tessel.io/start).
 
-<b>For details on Tessel and Tessel's modules,</b> including API and hardware design information, explore the links available at [tessel.io/docs](//tessel.io/docs).
+## Tessel 1 API Documentation
+
+* [Tessel 1 CLI](https://github.com/tessel/docs/blob/master/cli.md)
+* [Tessel 1 Hardware API (LEDs, pins, ports, etc.)](https://github.com/tessel/docs/blob/master/hardware-api.md)
+* [Modules on Tessel 1](https://github.com/tessel/docs/blob/master/module-apis.md)
+* [Connecting Tessel 1 to Wifi](https://github.com/tessel/docs/blob/master/wifi.md)
+* [Tessel 1 Languages and Compatibility](https://github.com/tessel/docs/blob/master/compatibility.md)
+
+## Tessel 1 Hardware Documentation
+
+* [Overview of Tessel 1's hardware](https://github.com/tessel/hardware/blob/master/tessel-hardware-overview.md)
+* [Powering Tessel 1](https://github.com/tessel/hardware/blob/master/powering-tessel.md)
+* [Adding a Wifi antenna to Tessel 1](https://github.com/tessel/hardware/blob/master/external-wifi-antenna.md)
+* [Tessel 1 design files](https://github.com/tessel/hardware/blob/master/design-files.md)
+* [Tessel Module hardware overview](https://github.com/tessel/hardware/blob/master/modules-overview.md)
+
+## Tessel 1 Tutorials
+
+* [Communication protocols](https://github.com/tessel/docs/blob/master/tutorials/communication-protocols.md)
+* [Making a DIY module](https://github.com/tessel/docs/blob/master/tutorials/diy_module_creation.md)
+* [Using multiple modules](https://github.com/tessel/docs/blob/master/tutorials/multi-module.md)
+* [Untethering Tessel](https://github.com/tessel/docs/blob/master/tutorials/untethered.md)
 
 If there's anything you can't find, something that isn't working, or documentation that we should add, please don't hesitate to <b>reach out to us</b> on the [Tessel forums](//forums.tessel.io).
 
-Technical Machine is open source, [hardware](//github.com/tessel/hardware) and [software](//github.com/tessel/firmware). We welcome your pull requests, and  we encourage you to design your own modules and products based on our designs. Check out the [contribution guide](//github.com/tessel/contribution-guide) for more details.
+Technical Machine is open source, [hardware](//github.com/tessel/hardware) and [software](//github.com/tessel/t1-firmware). We welcome your pull requests, and  we encourage you to design your own modules and products based on our designs. Check out the [contribution guide](//github.com/tessel/contribution-guide) for more details.
 
 Once you've made something (building block or whole system; both are useful), please share it with the community on the [Projects Page](http://tessel.hackster.io)!
 


### PR DESCRIPTION
Let's turn this outdated & weirdly labyrinthine set of docs into a static archive and unlink it from technical-io, to be replaced with links to a more cleverly structured t2-docs repo which I will now make.

@tcr r?